### PR TITLE
fix!: sort spans in functional tests by startTime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v2
+      - name: fetch tags
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - name: setup Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: create tag, bump versions and create commit
+        run: |
+          git config --local user.email "automatic-release@github.com"
+          git config --local user.name "automatic-release"
+          npx standard-version@7.1
+      - name: push changes
+        uses: ad-m/github-push-action@v0.5.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: create GitHub release
+        env:
+          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx conventional-github-releaser

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 os: linux
 dist: bionic
+if: tag IS blank
 
 jobs:
   include:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # auxmoney OpentracingBundle
 
+![release](https://github.com/auxmoney/OpentracingBundle-core/workflows/release/badge.svg)
+![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/auxmoney/OpentracingBundle-core)
+![Travis (.org)](https://img.shields.io/travis/auxmoney/OpentracingBundle-core)
+![Coveralls github](https://img.shields.io/coveralls/github/auxmoney/OpentracingBundle-core)
+![Codacy Badge](https://api.codacy.com/project/badge/Grade/fc044c88d4e046ab8813be04032a29a4)
+![Code Climate maintainability](https://img.shields.io/codeclimate/maintainability/auxmoney/OpentracingBundle-core)
+![Scrutinizer code quality (GitHub/Bitbucket)](https://img.shields.io/scrutinizer/quality/g/auxmoney/OpentracingBundle-core)
+![GitHub](https://img.shields.io/github/license/auxmoney/OpentracingBundle-core)
+
 This collection of symfony bundles provides everything needed for a symfony application to enable distributed tracing.
 
 It utilizes the [PHP implementation](https://github.com/opentracing/opentracing-php) of the [opentracing specification](https://opentracing.io/specification/) 


### PR DESCRIPTION
BREAKING CHANGE: functional tests must now select `startTime: startTime` in their `$expression` for `getSpansAsYAML()`