### PR TITLE
Add support for injecting into an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ If you do not use Guzzle, you need to inject the trace headers into every outgoi
 
 on the request and use the resulting request with your favorite request client.
 
+If you are using a request that is not PSR-7 compatible, you can inject the headers directly into an array using
+
+```php
+    Auxmoney\OpentracingBundle\Service\Tracing::injectTracingHeadersIntoCarrier(array $carrier): array
+```
+
+passing the array representing the headers of your request.
+
 ### Automatic tracing
 
 Out of the box, the bundle will trace some spans automatically:

--- a/Service/Tracing.php
+++ b/Service/Tracing.php
@@ -4,10 +4,20 @@ declare(strict_types=1);
 
 namespace Auxmoney\OpentracingBundle\Service;
 
+use OpenTracing\Exceptions\UnsupportedFormat;
 use Psr\Http\Message\RequestInterface;
 
 interface Tracing
 {
+    /**
+     * Injects necessary tracing headers into an array.
+     * @param array<mixed> $carrier
+     * @return array<mixed>
+     *
+     * @throws UnsupportedFormat when the format is not recognized by the tracer
+     */
+    public function injectTracingHeadersIntoCarrier(array $carrier): array;
+
     /**
      * Injects necessary tracing headers into a RequestInterface.
      *

--- a/Tests/Mock/MockTracer.php
+++ b/Tests/Mock/MockTracer.php
@@ -49,7 +49,7 @@ final class MockTracer implements Tracer
      */
     public function inject(SpanContext $spanContext, $format, &$carrier)
     {
-        $carrier = ['made_up_header' => '1:2:3:4'];
+        $carrier['made_up_header'] = '1:2:3:4';
     }
 
     public function extract($format, $carrier)

--- a/Tests/Service/TracingServiceTest.php
+++ b/Tests/Service/TracingServiceTest.php
@@ -45,6 +45,19 @@ class TracingServiceTest extends TestCase
         self::assertSame($newRequest->reveal(), $injectedRequest);
     }
 
+    public function testInjectTracingHeadersIntoCarrierSuccess(): void
+    {
+        $this->mockTracer->startActiveSpan('test span');
+
+        $headers = [ 'abc' => '123' ];
+
+        $this->logger->warning(Argument::type('string'))->shouldNotBeCalled();
+
+        $newHeaders = $this->subject->injectTracingHeadersIntoCarrier($headers);
+        self::assertSame([ 'abc' => '123' ], $headers);
+        self::assertSame([ 'abc' => '123', 'made_up_header' => '1:2:3:4' ], $newHeaders);
+    }
+
     public function testInjectTracingHeadersNoActiveSpan(): void
     {
         $originalRequest = $this->prophesize(RequestInterface::class);
@@ -54,6 +67,19 @@ class TracingServiceTest extends TestCase
 
         $injectedRequest = $this->subject->injectTracingHeaders($originalRequest->reveal());
         self::assertSame($originalRequest->reveal(), $injectedRequest);
+    }
+
+    public function testInjectTracingHeadersIntoCarrierNoActiveSpan(): void
+    {
+        $originalRequest = $this->prophesize(RequestInterface::class);
+
+        $headers = [ 'abc' => '123' ];
+
+        $this->logger->warning(Argument::type('string'))->shouldBeCalled();
+
+        $newHeaders = $this->subject->injectTracingHeadersIntoCarrier($headers);
+        self::assertSame([ 'abc' => '123' ], $headers);
+        self::assertSame($headers, $newHeaders);
     }
 
     public function testStartActiveSpanWithoutOptionsSuccess(): void


### PR DESCRIPTION
Would you be ok to support injecting context into an array instead of `Psr\Http\Message\RequestInterface` ?

It would allow for easier integration into existing code.

Thanks.