### PR TITLE
WIP: feat!: add sampler configuration

### DIFF
--- a/Factory/TracerFactory.php
+++ b/Factory/TracerFactory.php
@@ -8,5 +8,14 @@ use OpenTracing\Tracer;
 
 interface TracerFactory
 {
-    public function create(string $projectName, string $agentHost, string $agentPort): Tracer;
+    /**
+     * @param mixed $samplerValue
+     */
+    public function create(
+        string $projectName,
+        string $agentHost,
+        string $agentPort,
+        string $samplerClass,
+        $samplerValue
+    ): Tracer;
 }

--- a/Internal/CachedOpentracing.php
+++ b/Internal/CachedOpentracing.php
@@ -17,19 +17,30 @@ final class CachedOpentracing implements Opentracing
     private $agentHost;
     private $agentPort;
     private $logger;
+    private $samplerClass;
 
+    /** @var mixed */
+    private $samplerValue;
+
+    /**
+     * @param mixed $samplerValue
+     */
     public function __construct(
         TracerFactory $tracerFactory,
         LoggerInterface $logger,
         string $projectName,
         string $agentHost,
-        string $agentPort
+        string $agentPort,
+        string $samplerClass,
+        $samplerValue
     ) {
         $this->tracerFactory = $tracerFactory;
         $this->logger = $logger;
         $this->projectName = $projectName;
         $this->agentHost = $agentHost;
         $this->agentPort = $agentPort;
+        $this->samplerClass = $samplerClass;
+        $this->samplerValue = $samplerValue;
     }
 
     public function getTracerInstance(): Tracer
@@ -38,7 +49,9 @@ final class CachedOpentracing implements Opentracing
             $this->tracerInstance = $this->tracerFactory->create(
                 $this->projectName,
                 $this->agentHost,
-                $this->agentPort
+                $this->agentPort,
+                $this->samplerClass,
+                $this->samplerValue
             );
 
             $this->logger->debug(

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -3,11 +3,16 @@ parameters:
   env(AUXMONEY_OPENTRACING_AGENT_HOST): localhost
   # env(AUXMONEY_OPENTRACING_AGENT_PORT) will be provided by packages which provide auxmoney/opentracing-bundle-tracer-implementation
   env(AUXMONEY_OPENTRACING_PROJECT_NAME): 'default will be provided by extension (basename(kernel.project_dir))'
+  # env(AUXMONEY_OPENTRACING_SAMPLER_CLASS) will be provided by packages which provide auxmoney/opentracing-bundle-tracer-implementation
+  # env(AUXMONEY_OPENTRACING_SAMPLER_VALUE) will be provided by packages which provide auxmoney/opentracing-bundle-tracer-implementation
 
   auxmoney_opentracing.hostname: '%env(HOSTNAME)%'
   auxmoney_opentracing.agent.host: '%env(AUXMONEY_OPENTRACING_AGENT_HOST)%'
   auxmoney_opentracing.agent.port: '%env(AUXMONEY_OPENTRACING_AGENT_PORT)%'
   auxmoney_opentracing.project.name: '%env(AUXMONEY_OPENTRACING_PROJECT_NAME)%'
+  auxmoney_opentracing.sampler.class: '%env(AUXMONEY_OPENTRACING_SAMPLER_CLASS)%'
+  auxmoney_opentracing.sampler.value: '%env(AUXMONEY_OPENTRACING_SAMPLER_VALUE)%'
+
 
 services:
   _defaults:
@@ -43,6 +48,8 @@ services:
       $projectName: '%auxmoney_opentracing.project.name%'
       $agentHost: '%auxmoney_opentracing.agent.host%'
       $agentPort: '%auxmoney_opentracing.agent.port%'
+      $samplerClass: '%auxmoney_opentracing.sampler.class%'
+      $samplerValue: '%auxmoney_opentracing.sampler.value%'
 
   Auxmoney\OpentracingBundle\Internal\Persistence:
     class: Auxmoney\OpentracingBundle\Internal\PersistenceService

--- a/Tests/Internal/CachedOpentracingTest.php
+++ b/Tests/Internal/CachedOpentracingTest.php
@@ -20,6 +20,8 @@ class CachedOpentracingTest extends TestCase
     private $tracerFactory;
     /** @var CachedOpentracing */
     private $subject;
+    private $samplerClass;
+    private $samplerValue;
 
     public function setUp()
     {
@@ -29,13 +31,17 @@ class CachedOpentracingTest extends TestCase
         $this->projectName = 'project name';
         $this->agentHost = 'agent host';
         $this->agentPort = '1234';
+        $this->samplerClass = 'Foo';
+        $this->samplerValue = true;
 
         $this->subject = new CachedOpentracing(
             $this->tracerFactory->reveal(),
             $this->logger->reveal(),
             $this->projectName,
             $this->agentHost,
-            $this->agentPort
+            $this->agentPort,
+            $this->samplerClass,
+            $this->samplerValue
         );
     }
 
@@ -43,7 +49,7 @@ class CachedOpentracingTest extends TestCase
     {
         $this->logger->debug(Argument::any())->shouldBeCalledOnce();
 
-        $this->tracerFactory->create($this->projectName, $this->agentHost, $this->agentPort)->willReturn(new MockTracer());
+        $this->tracerFactory->create($this->projectName, $this->agentHost, $this->agentPort, $this->samplerClass, $this->samplerValue)->willReturn(new MockTracer());
 
         $tracer1 = $this->subject->getTracerInstance();
         $tracer2 = $this->subject->getTracerInstance();


### PR DESCRIPTION
BREAKING CHANGES: tracer implementation plugins will need to update their factories to respect two new arguments: `string $samplerClass` and `mixed $samplerValue`

relates to #4 