### PR TITLE
Wrap calls to flush in try catch

### DIFF
--- a/Internal/PersistenceService.php
+++ b/Internal/PersistenceService.php
@@ -22,7 +22,7 @@ final class PersistenceService implements Persistence
         try {
             $this->tracer->flush();
         } catch (\Throwable $exception) {
-            $this->logger->warning('Failed to flush tracer : ' . $exception->getMessage());
+            $this->logger->warning(self::class . ': Failed to flush tracer : ' . $exception->getMessage());
         }
     }
 }

--- a/Internal/PersistenceService.php
+++ b/Internal/PersistenceService.php
@@ -4,17 +4,26 @@ declare(strict_types=1);
 
 namespace Auxmoney\OpentracingBundle\Internal;
 
+use Psr\Log\LoggerInterface;
+use ReflectionException;
+
 final class PersistenceService implements Persistence
 {
     private $tracer;
+    private $logger;
 
-    public function __construct(Opentracing $opentracing)
+    public function __construct(Opentracing $opentracing, LoggerInterface $logger)
     {
         $this->tracer = $opentracing->getTracerInstance();
+        $this->logger = $logger;
     }
 
     public function flush(): void
     {
-        $this->tracer->flush();
+        try {
+            $this->tracer->flush();
+        } catch (ReflectionException $exception) {
+            $this->logger->warning('Failed to flush tracer : ' . $exception->getMessage());
+        }
     }
 }

--- a/Internal/PersistenceService.php
+++ b/Internal/PersistenceService.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Auxmoney\OpentracingBundle\Internal;
 
 use Psr\Log\LoggerInterface;
-use ReflectionException;
 
 final class PersistenceService implements Persistence
 {
@@ -22,7 +21,7 @@ final class PersistenceService implements Persistence
     {
         try {
             $this->tracer->flush();
-        } catch (ReflectionException $exception) {
+        } catch (\Throwable $exception) {
             $this->logger->warning('Failed to flush tracer : ' . $exception->getMessage());
         }
     }

--- a/Internal/PersistenceService.php
+++ b/Internal/PersistenceService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Auxmoney\OpentracingBundle\Internal;
 
+use Exception;
 use Psr\Log\LoggerInterface;
 
 final class PersistenceService implements Persistence
@@ -21,7 +22,7 @@ final class PersistenceService implements Persistence
     {
         try {
             $this->tracer->flush();
-        } catch (\Throwable $exception) {
+        } catch (Exception $exception) {
             $this->logger->warning(self::class . ': Failed to flush tracer : ' . $exception->getMessage());
         }
     }

--- a/Tests/Internal/PersistenceServiceTest.php
+++ b/Tests/Internal/PersistenceServiceTest.php
@@ -8,6 +8,8 @@ use Auxmoney\OpentracingBundle\Internal\Opentracing;
 use Auxmoney\OpentracingBundle\Internal\PersistenceService;
 use Auxmoney\OpentracingBundle\Tests\Mock\MockTracer;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
 
 class PersistenceServiceTest extends TestCase
 {
@@ -17,6 +19,7 @@ class PersistenceServiceTest extends TestCase
     {
         parent::setUp();
         $this->opentracing = $this->prophesize(Opentracing::class);
+        $this->logger = $this->prophesize(LoggerInterface::class);
     }
 
     public function testFlushSuccess(): void
@@ -24,11 +27,26 @@ class PersistenceServiceTest extends TestCase
         $mockTracer = new MockTracer();
         $mockTracer->startActiveSpan('operation name');
         $this->opentracing->getTracerInstance()->willReturn($mockTracer);
+        $this->logger->warning(Argument::type('string'))->shouldNotBeCalled();
 
-        $subject = new PersistenceService($this->opentracing->reveal());
+        $subject = new PersistenceService($this->opentracing->reveal(), $this->logger->reveal());
 
         $subject->flush();
 
         self::assertEmpty($mockTracer->getSpans());
+    }
+
+    public function testFlushThrowsException(): void
+    {
+        $mockTracer = $this->prophesize(MockTracer::class);
+        $mockTracer->flush()->willThrow(new RuntimeException('exception happened'));
+        $mockTracer->reveal()->startActiveSpan('operation name');
+
+        $this->opentracing->getTracerInstance()->willReturn($mockTracer->reveal());
+        $this->logger->warning(Argument::type('string'))->shouldBeCalled();
+
+        $subject = new PersistenceService($this->opentracing->reveal(), $this->logger->reveal());
+
+        $subject->flush();
     }
 }

--- a/Tests/Internal/PersistenceServiceTest.php
+++ b/Tests/Internal/PersistenceServiceTest.php
@@ -10,6 +10,7 @@ use Auxmoney\OpentracingBundle\Tests\Mock\MockTracer;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 class PersistenceServiceTest extends TestCase
 {
@@ -40,7 +41,6 @@ class PersistenceServiceTest extends TestCase
     {
         $mockTracer = $this->prophesize(MockTracer::class);
         $mockTracer->flush()->willThrow(new RuntimeException('exception happened'));
-        $mockTracer->reveal()->startActiveSpan('operation name');
 
         $this->opentracing->getTracerInstance()->willReturn($mockTracer->reveal());
         $this->logger->warning(Argument::type('string'))->shouldBeCalled();

--- a/Tests/Mock/MockTracer.php
+++ b/Tests/Mock/MockTracer.php
@@ -10,7 +10,7 @@ use OpenTracing\SpanContext;
 use OpenTracing\Tracer;
 use const OpenTracing\Formats\TEXT_MAP;
 
-final class MockTracer implements Tracer
+class MockTracer implements Tracer
 {
     private $mockTracer;
 


### PR DESCRIPTION
Solves issue #25 
I had to remove the `final` in `MockTracer` to allow mocking `->flush()`.
I am definitely not a php expert, if things need to be improved i'll be happy to update the PR.