### PR TITLE
Fix kernel.response event not matching a kernel.controller event

### DIFF
--- a/EventListener/FinishControllerSpanSubscriber.php
+++ b/EventListener/FinishControllerSpanSubscriber.php
@@ -39,8 +39,13 @@ final class FinishControllerSpanSubscriber implements EventSubscriberInterface
      */
     public function onResponse($event): void
     {
-        $this->tracing->setTagOfActiveSpan(HTTP_STATUS_CODE, $this->getHttpStatusCode($event) ?? 'not determined');
-        $this->tracing->finishActiveSpan();
+        $attributes = $event->getRequest()->attributes;
+
+        // This check ensures there was a span started on a corresponding kernel.controller event for this request
+        if ($attributes->has('_controller')) {
+            $this->tracing->setTagOfActiveSpan(HTTP_STATUS_CODE, $this->getHttpStatusCode($event) ?? 'not determined');
+            $this->tracing->finishActiveSpan();
+        }
     }
 
     /**

--- a/Tests/Mock/EventWithNoResponse.php
+++ b/Tests/Mock/EventWithNoResponse.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Auxmoney\OpentracingBundle\Tests\Mock;
 
-use ReflectionException;
 use Symfony\Component\HttpFoundation\Request;
 
-final class EventWithResponseAndReflectionError
+final class EventWithNoResponse
 {
     private $request;
 
@@ -19,13 +18,5 @@ final class EventWithResponseAndReflectionError
     public function getRequest(): Request
     {
         return $this->request;
-    }
-    
-    /**
-     * @throws ReflectionException
-     */
-    public function getResponse(): void
-    {
-        throw new ReflectionException('could not get response!');
     }
 }

--- a/Tests/Mock/EventWithResponse.php
+++ b/Tests/Mock/EventWithResponse.php
@@ -5,9 +5,22 @@ declare(strict_types=1);
 namespace Auxmoney\OpentracingBundle\Tests\Mock;
 
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
 
 final class EventWithResponse
 {
+    private $request;
+
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+
     public function getResponse(): Response
     {
         return new Response();


### PR DESCRIPTION
Should fix https://github.com/auxmoney/OpentracingBundle-core/issues/31

Check if the request has the `_controller` attribute when in the `kernel.response` event handler.
This males sur we went through the `kernel.controller` event handler and started a span.