### PR TITLE
Could not finish active span, missing active scope (part 2)

### DIFF
--- a/EventListener/FinishControllerSpanSubscriber.php
+++ b/EventListener/FinishControllerSpanSubscriber.php
@@ -42,7 +42,7 @@ final class FinishControllerSpanSubscriber implements EventSubscriberInterface
         $attributes = $event->getRequest()->attributes;
 
         // This check ensures there was a span started on a corresponding kernel.controller event for this request
-        if ($attributes->has('_controller')) {
+        if ($attributes->has('_auxmoney_controller')) {
             $this->tracing->setTagOfActiveSpan(HTTP_STATUS_CODE, $this->getHttpStatusCode($event) ?? 'not determined');
             $this->tracing->finishActiveSpan();
         }

--- a/EventListener/StartControllerSpanSubscriber.php
+++ b/EventListener/StartControllerSpanSubscriber.php
@@ -30,6 +30,7 @@ final class StartControllerSpanSubscriber implements EventSubscriberInterface
     public function onController(KernelEvent $event): void
     {
         $attributes = $event->getRequest()->attributes;
+        $attributes->set('_auxmoney_controller', true);
         $this->tracing->startActiveSpan(
             $attributes->get('_controller'),
             [

--- a/Tests/EventListener/FinishControllerSpanSubscriberTest.php
+++ b/Tests/EventListener/FinishControllerSpanSubscriberTest.php
@@ -41,7 +41,8 @@ class FinishControllerSpanSubscriberTest extends TestCase
             [
                 '_controller' => 'controller name',
                 '_route' => 'controller route',
-                '_route_params' => ['a route' => 'param', 'and' => 5]
+                '_route_params' => ['a route' => 'param', 'and' => 5],
+                '_auxmoney_controller' => true
             ]
         );
 
@@ -70,7 +71,8 @@ class FinishControllerSpanSubscriberTest extends TestCase
             [
                 '_controller' => 'controller name',
                 '_route' => 'controller route',
-                '_route_params' => ['a route' => 'param', 'and' => 5]
+                '_route_params' => ['a route' => 'param', 'and' => 5],
+                '_auxmoney_controller' => true
             ]
         );
 
@@ -88,7 +90,8 @@ class FinishControllerSpanSubscriberTest extends TestCase
             [
                 '_controller' => 'controller name',
                 '_route' => 'controller route',
-                '_route_params' => ['a route' => 'param', 'and' => 5]
+                '_route_params' => ['a route' => 'param', 'and' => 5],
+                '_auxmoney_controller' => true
             ]
         );
 


### PR DESCRIPTION
This PR is a second attempt to fix #31. It introduces a request attribute `_auxmoney_controller` that we have control over.

The previous attempt tried to use the `_controller` attribute but it didn't solve the issue.
Hopefully this one should do it as we control the attribute, it's easier to ensure it is set/checked at appropriate points in the request lifecycle.
