### PR TITLE
Route tag can be omitted with controller functions

### DIFF
--- a/EventListener/StartControllerSpanSubscriber.php
+++ b/EventListener/StartControllerSpanSubscriber.php
@@ -32,14 +32,20 @@ final class StartControllerSpanSubscriber implements EventSubscriberInterface
     {
         $attributes = $event->getRequest()->attributes;
         $attributes->set('_auxmoney_controller', true);
+
+        $tags = [
+            Constant::SPAN_ORIGIN => 'core:controller',
+        ];
+
+        if ($attributes->get('_route')) {
+            $tags['route'] = $attributes->get('_route');
+            $tags['route_params'] = json_encode($attributes->get('_route_params'));
+        }
+
         $this->tracing->startActiveSpan(
             $attributes->get('_controller'),
             [
-                'tags' => [
-                    'route' => $attributes->get('_route'),
-                    'route_params' => json_encode($attributes->get('_route_params')),
-                    Constant::SPAN_ORIGIN => 'core:controller',
-                ]
+                'tags' => $tags
             ]
         );
     }

--- a/Tests/EventListener/StartControllerSpanSubscriberTest.php
+++ b/Tests/EventListener/StartControllerSpanSubscriberTest.php
@@ -48,4 +48,23 @@ class StartControllerSpanSubscriberTest extends TestCase
 
         $this->subject->onController($event->reveal());
     }
+
+    public function testOnControllerWithoutRoute(): void
+    {
+        $request = new Request();
+        $request->attributes->add(
+            [
+                '_controller' => 'controller name',
+            ]
+        );
+        $event = $this->prophesize(KernelEvent::class);
+        $event->getRequest()->willReturn($request);
+
+        $this->tracing->startActiveSpan(
+            'controller name',
+            ['tags' => ['auxmoney-opentracing-bundle.span-origin' => 'core:controller']]
+        )->shouldBeCalledOnce();
+
+        $this->subject->onController($event->reveal());
+    }
 }


### PR DESCRIPTION
Hello,
I'm working on an implementation of this `OpentracingBundle` for Instana: https://github.com/prismamedia/opentracing-bundle-instana/pull/1 testing on Symfony demo app.

In some cases, the controllers can be called without any route matched. For example, when the `controller()` helper is used in Twig. https://github.com/symfony/demo/blob/52ef1b74ef3276f0c0258ec24e9dc0de0312d407/templates/base.html.twig#L116-L120

The Instana implementation of Opentracing throw an exception when the value of a tag is null.
https://github.com/instana/instana-php-opentracing/blob/416b981ceaf4138e85cdbb6a230f7411ce5f8c6c/src/Instana/OpenTracing/InstanaSpan.php#L148

This PR solves this issue by removing `route` and `route_parameters` tags when the request doesn't have a `_route` attribute.