### PR TITLE
Provide default error message, as zipkin will throw exception for empty annotations

### DIFF
--- a/EventListener/ExceptionLogSubscriber.php
+++ b/EventListener/ExceptionLogSubscriber.php
@@ -12,6 +12,8 @@ use Throwable;
 
 final class ExceptionLogSubscriber implements EventSubscriberInterface
 {
+    const DEFAULT_ERROR_MESSAGE = "No error message given";
+
     private $tracing;
 
     public function __construct(Tracing $tracing)
@@ -42,7 +44,7 @@ final class ExceptionLogSubscriber implements EventSubscriberInterface
                 'event' => 'error',
                 'error.kind' => 'Exception',
                 'error.object' => get_class($exception),
-                'message' => $exception->getMessage(),
+                'message' => $exception->getMessage() ? $exception->getMessage() : self::DEFAULT_ERROR_MESSAGE,
                 'stack' => $exception->getTraceAsString(),
             ]
         );

--- a/EventListener/ExceptionLogSubscriber.php
+++ b/EventListener/ExceptionLogSubscriber.php
@@ -12,7 +12,7 @@ use Throwable;
 
 final class ExceptionLogSubscriber implements EventSubscriberInterface
 {
-    const DEFAULT_ERROR_MESSAGE = "No error message given";
+    private const DEFAULT_ERROR_MESSAGE = "No error message given";
 
     private $tracing;
 

--- a/EventListener/ExceptionLogSubscriber.php
+++ b/EventListener/ExceptionLogSubscriber.php
@@ -44,7 +44,7 @@ final class ExceptionLogSubscriber implements EventSubscriberInterface
                 'event' => 'error',
                 'error.kind' => 'Exception',
                 'error.object' => get_class($exception),
-                'message' => $exception->getMessage() ? $exception->getMessage() : self::DEFAULT_ERROR_MESSAGE,
+                'message' => $exception->getMessage() ?: self::DEFAULT_ERROR_MESSAGE,
                 'stack' => $exception->getTraceAsString(),
             ]
         );

--- a/Tests/EventListener/ExceptionLogSubscriberTest.php
+++ b/Tests/EventListener/ExceptionLogSubscriberTest.php
@@ -104,7 +104,7 @@ class ExceptionLogSubscriberTest extends TestCase
     {
         $this->tracing->logInActiveSpan(Argument::that(function (array $argument) {
             self::assertArrayHasKey('message', $argument);
-            self::assertEquals(ExceptionLogSubscriber::DEFAULT_ERROR_MESSAGE, $argument['message']);
+            self::assertEquals("No error message given", $argument['message']);
             return true;
         }))->shouldBeCalledOnce();
 

--- a/Tests/EventListener/ExceptionLogSubscriberTest.php
+++ b/Tests/EventListener/ExceptionLogSubscriberTest.php
@@ -8,6 +8,7 @@ use Auxmoney\OpentracingBundle\EventListener\ExceptionLogSubscriber;
 use Auxmoney\OpentracingBundle\Tests\Mock\EventReflectionError;
 use Auxmoney\OpentracingBundle\Tests\Mock\EventWithError;
 use Auxmoney\OpentracingBundle\Tests\Mock\EventWithException;
+use Auxmoney\OpentracingBundle\Tests\Mock\EventWithExceptionWithoutErrorMessage;
 use Auxmoney\OpentracingBundle\Tests\Mock\EventWithThrowable;
 use Auxmoney\OpentracingBundle\Service\Tracing;
 use PHPUnit\Framework\TestCase;
@@ -97,5 +98,16 @@ class ExceptionLogSubscriberTest extends TestCase
         }))->shouldBeCalledOnce();
 
         $this->subject->onException(new stdClass());
+    }
+
+    public function testProvidingDefaultExceptionMessageAsLogsCanNotBeEmpty(): void
+    {
+        $this->tracing->logInActiveSpan(Argument::that(function (array $argument) {
+            self::assertArrayHasKey('message', $argument);
+            self::assertEquals(ExceptionLogSubscriber::DEFAULT_ERROR_MESSAGE, $argument['message']);
+            return true;
+        }))->shouldBeCalledOnce();
+
+        $this->subject->onException(new EventWithExceptionWithoutErrorMessage());
     }
 }

--- a/Tests/Mock/EventWithExceptionWithoutErrorMessage.php
+++ b/Tests/Mock/EventWithExceptionWithoutErrorMessage.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auxmoney\OpentracingBundle\Tests\Mock;
+
+use Exception;
+
+final class EventWithExceptionWithoutErrorMessage
+{
+    public function getException(): Exception
+    {
+        return new Exception("");
+    }
+}


### PR DESCRIPTION
This PR provides an default error message, as zipkin integration does not allow for empty annotations. 