### PR TITLE
chore: update opentracing-php to 1.0.1

### DIFF
--- a/Factory/RequestSpanOptionsFactory.php
+++ b/Factory/RequestSpanOptionsFactory.php
@@ -29,7 +29,7 @@ final class RequestSpanOptionsFactory implements SpanOptionsFactory
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
     public function createSpanOptions(Request $request = null): array

--- a/Service/Tracing.php
+++ b/Service/Tracing.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Auxmoney\OpentracingBundle\Service;
 
-use OpenTracing\Exceptions\UnsupportedFormat;
+use OpenTracing\UnsupportedFormatException;
 use Psr\Http\Message\RequestInterface;
 
 interface Tracing
@@ -14,7 +14,7 @@ interface Tracing
      * @param array<mixed> $carrier
      * @return array<mixed>
      *
-     * @throws UnsupportedFormat when the format is not recognized by the tracer
+     * @throws UnsupportedFormatException when the format is not recognized by the tracer
      */
     public function injectTracingHeadersIntoCarrier(array $carrier): array;
 

--- a/Service/TracingService.php
+++ b/Service/TracingService.php
@@ -7,7 +7,7 @@ namespace Auxmoney\OpentracingBundle\Service;
 use Auxmoney\OpentracingBundle\Internal\Opentracing;
 use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
-use OpenTracing\Exceptions\UnsupportedFormat;
+use OpenTracing\UnsupportedFormatException;
 use OpenTracing\Span;
 
 use const OpenTracing\Formats\TEXT_MAP;
@@ -98,7 +98,7 @@ final class TracingService implements Tracing
      * @param array<mixed> $carrier
      * @return array<mixed>
      *
-     * @throws UnsupportedFormat when the format is not recognized by the tracer
+     * @throws UnsupportedFormatException when the format is not recognized by the tracer
      */
     private function doInjectTracingHeadersIntoCarrier(Span $span, array $carrier): array
     {

--- a/Tests/Mock/MockTracer.php
+++ b/Tests/Mock/MockTracer.php
@@ -6,6 +6,8 @@ namespace Auxmoney\OpentracingBundle\Tests\Mock;
 
 use OpenTracing\Mock\MockSpan;
 use OpenTracing\Mock\MockTracer as OriginalMockTracer;
+use OpenTracing\Scope;
+use OpenTracing\ScopeManager;
 use OpenTracing\Span;
 use OpenTracing\SpanContext;
 use OpenTracing\Tracer;
@@ -25,7 +27,7 @@ class MockTracer implements Tracer
         );
     }
 
-    public function getScopeManager()
+    public function getScopeManager(): ScopeManager
     {
         return $this->mockTracer->getScopeManager();
     }
@@ -35,12 +37,12 @@ class MockTracer implements Tracer
         return $this->mockTracer->getActiveSpan();
     }
 
-    public function startActiveSpan($operationName, $options = [])
+    public function startActiveSpan(string $operationName, $options = []): Scope
     {
         return $this->mockTracer->startActiveSpan($operationName, $options);
     }
 
-    public function startSpan($operationName, $options = [])
+    public function startSpan(string $operationName, $options = []): Span
     {
         return $this->mockTracer->startSpan($operationName, $options);
     }
@@ -48,12 +50,12 @@ class MockTracer implements Tracer
     /**
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function inject(SpanContext $spanContext, $format, &$carrier): void
+    public function inject(SpanContext $spanContext, string $format, &$carrier): void
     {
         $carrier['made_up_header'] = '1:2:3:4';
     }
 
-    public function extract($format, $carrier)
+    public function extract(string $format, $carrier): ?SpanContext
     {
         return $this->mockTracer->extract($format, $carrier);
     }

--- a/Tests/Mock/MockTracer.php
+++ b/Tests/Mock/MockTracer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Auxmoney\OpentracingBundle\Tests\Mock;
 
 use OpenTracing\Mock\MockSpan;
+use OpenTracing\Mock\MockSpanContext;
 use OpenTracing\Mock\MockTracer as OriginalMockTracer;
 use OpenTracing\Scope;
 use OpenTracing\ScopeManager;
@@ -22,7 +23,9 @@ class MockTracer implements Tracer
         $this->mockTracer = new OriginalMockTracer(
             [],
             [
-                TEXT_MAP => 'OpenTracing\Mock\MockSpanContext::createAsRoot'
+                TEXT_MAP => static function (array $items): MockSpanContext {
+                    return MockSpanContext::createAsRoot(true, $items);
+                }
             ]
         );
     }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "psr/log": "^1.1",
     "psr/http-message": "^1.0",
     "psr/http-client": "^1.0",
-    "opentracing/opentracing": "1.0.0-beta5@beta",
+    "opentracing/opentracing": "^1.0",
     "composer/package-versions-deprecated": "^1.11.99",
     "symfony/http-kernel": "^3.4|^4.4|^5.2",
     "symfony/dependency-injection": "^3.4|^4.4|^5.2",


### PR DESCRIPTION
This adds support for opentracing ^1.0. Since nothing really changed there since beta5 apart from type-hinting, strict typing and a minor exceptions refactoring (see https://github.com/opentracing/opentracing-php/compare/1.0.0-beta5...1.0.1), I think nothing should be broken here as well (unless it has been like that already). There are two further API extensions in case those are of any interest here - new method [`GlobalTracer::isRegistered`](https://github.com/opentracing/opentracing-php/blob/31d2604bd01a1508307b74949fbe1a6683284834/src/OpenTracing/GlobalTracer.php#L51-L59) and `StartSpanOptions::create` [now checks and sets](https://github.com/opentracing/opentracing-php/blob/31d2604bd01a1508307b74949fbe1a6683284834/src/OpenTracing/StartSpanOptions.php#L106-L112) `ignore_active_span` option.

Closes #54 