### PR TITLE
fix: Move Trace-Propagation to Terminate Event

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/EventListener/FinishRootSpanSubscriber.php
+++ b/EventListener/FinishRootSpanSubscriber.php
@@ -27,6 +27,7 @@ final class FinishRootSpanSubscriber implements EventSubscriberInterface
     {
         return [
             'kernel.finish_request' => ['onFinishRequest', -16],
+            'kernel.terminate' => ['onTerminate', -16],
         ];
     }
 
@@ -44,6 +45,21 @@ final class FinishRootSpanSubscriber implements EventSubscriberInterface
         }
 
         $this->tracing->finishActiveSpan();
+    }
+
+    public function onTerminate(KernelEvent $event): void
+    {
+        # TODO: when Symfony 4.4 is unmaintained (November 2023), remove outer if-block in favor of isMainRequest()
+        if (method_exists($event, 'isMainRequest')) {
+            if (!$event->isMainRequest()) {
+                return;
+            }
+        } elseif (method_exists($event, 'isMasterRequest')) {
+            if (!$event->isMasterRequest()) {
+                return;
+            }
+        }
+
         $this->persistence->flush();
     }
 }


### PR DESCRIPTION
Hey there, I had noticed this when I was trying to overwrite some of the Controller Spanning for a Healthcheck Controller. Figured I would make a PR (and perhaps a few more) for it.

Is there a reason the trace flush was in the `finish_request` Event? That Event fires *before* the response is sent, making it less than ideal for this